### PR TITLE
Fix: タップイベントのリスナー解除ができてないのを修正

### DIFF
--- a/js/adapter/TapEventListener.mjs
+++ b/js/adapter/TapEventListener.mjs
@@ -2,15 +2,18 @@
 export class TapEventListener {
     constructor(canvas) {
         this.canvas = canvas;
+        this.listeners = new Set();
     }
 
     // 新たなイベントを登録
     addListener(listener) {
+        this.listeners.add(listener);
         this.canvas.addEventListener("click", listener);
     }
 
-    // 登録したイベントの解除
-    removeListener(listener) {
-        this.canvas.removeEventListener('click', listener);
+    // 登録したイベントを全て解除
+    clearListeners() {
+        this.listeners.forEach(listener => this.canvas.removeEventListener('click', listener));
+        this.listeners.clear();
     }
 }

--- a/js/scene/TitleScene.mjs
+++ b/js/scene/TitleScene.mjs
@@ -27,7 +27,7 @@ export class TitleScene extends Scene {
     }
 
     destroy() {
-        this.tapEventListener.removeListener(this.didTapStartFromBeginning.bind(this));
+        this.tapEventListener.clearListeners();
     }
 
     // 「最初から始める」をクリックした時の処理

--- a/js/scene/TitleScene.mjs
+++ b/js/scene/TitleScene.mjs
@@ -10,7 +10,7 @@ export class TitleScene extends Scene {
     }
 
     init() {
-        this.tapEventListener.addListener(this.didTapStartFromBeginning.bind(this));
+        this.tapEventListener.addListener(this.onTap.bind(this));
         this.startFromBeginningButtonRange = null
     }
 
@@ -30,13 +30,18 @@ export class TitleScene extends Scene {
         this.tapEventListener.clearListeners();
     }
 
-    // 「最初から始める」をクリックした時の処理
-    didTapStartFromBeginning(event) {
+    // 画面内のどこかがタップされた
+    onTap(event) {
         const x = event.offsetX;
         const y = event.offsetY;
-        let r = this.startFromBeginningButtonRange;
+        const r = this.startFromBeginningButtonRange;
         if (r && x >= r.x && x <= r.x+r.w && y >= r.y && y <= r.y+r.h) {
-            this.changeScene?.(scenes.arasuji);
+            this.didTapStartFromBeginning();
         }
+    }
+
+    // 「最初から始める」をタップした時の処理
+    didTapStartFromBeginning() {
+        this.changeScene?.(scenes.arasuji);
     }
 }


### PR DESCRIPTION
close #3

`addListener` する時と `removeListener` する時にそれぞれ `this.method.bind(this)` してたんですが、`.bind` する毎に毎回違うインスタンスができてしまうために、うまくremoveできてなかったっぽいです。