### PR TITLE
Feature: SlotSelectionSceneの各スロットにスロットの概要を記述

### DIFF
--- a/js/dataObject/Slot.mjs
+++ b/js/dataObject/Slot.mjs
@@ -17,4 +17,14 @@ export class Slot {
     withAddedStageResult(stageResult) {
         return new Slot([...this.stageResults, stageResult], this.ending);
     }
+
+    maxStageNumber(){
+        if(this.stageResults.length === 0){
+            return 1;
+        } else {
+            return this.stageResults.reduce((max, result) => {
+                return Math.max(max,result.stage.stageNumber);
+            }, 1);
+        }
+    }
 }

--- a/js/scene/SlotSelectionScene.mjs
+++ b/js/scene/SlotSelectionScene.mjs
@@ -56,10 +56,17 @@ export class SlotSelectionScene extends Scene {
             ctx.textAlign = "left";
             ctx.textBaseline = "middle";
 
+            let slotOverViewText;
             const slots = this.sceneRouter.load(dataKeys.slots);
-            let slot = slots[i + 1] ?? new Slot();
-            const endingNameToDisplay = endingName[slot.ending] ?? "";
-            ctx.fillText(endingNameToDisplay, r.x + r.w / 2 + 130, r.y + r.h / 2);
+            const slot = slots[i + 1];
+            if(!slot){
+                slotOverViewText = "空きスロット"
+            } else if(slot.ending){ 
+                slotOverViewText = endingName[slot.ending];
+            } else {
+                slotOverViewText = `ステージ${slot.maxStageNumber()}までクリア`;
+            }
+            ctx.fillText(slotOverViewText, r.x + r.w / 2 + 130, r.y + r.h / 2);
 
         }
     }


### PR DESCRIPTION
close #61 

スロット選択画面の各スロットの右側にスロットの概要を記述する

スロットが空　→　"空きスロット"
ステージnまでプレイ　→　"ステージnまでクリア"
エンディングを達成　→　"エンディング名"