### PR TITLE
Feature: CookingSceneのピザの画像を解禁状態に合わせて表示・非表示

### DIFF
--- a/js/scene/CookingScene.mjs
+++ b/js/scene/CookingScene.mjs
@@ -125,7 +125,7 @@ export class CookingScene extends Scene {
             ctx.font = "24px Arial";
             ctx.textAlign = "center";
             ctx.fillStyle = "black";
-            ctx.fillText(`${name}`, x + width / 2, y + 20);
+            ctx.fillText(`${isUnlocked ? name : "???"}`, x + width / 2, y + 20);
 
         }
     }

--- a/js/scene/CookingScene.mjs
+++ b/js/scene/CookingScene.mjs
@@ -4,6 +4,7 @@ import { imageForIngredient, ingredientName } from '../gameObject/ingredients.mj
 import { getPizza, imageForPizza, pizzaName } from '../gameObject/pizzas.mjs';
 import { resource } from '../resource.mjs';
 import { dataKeys } from '../dataObject/dataKeysSettings.mjs';
+import { PizzaInfo } from '../dataObject/PizzaInfo.mjs';
 
 import { ingredientType } from '../gameObject/ingredients.mjs';
 
@@ -18,8 +19,17 @@ export class CookingScene extends Scene {
             this.sharedData.selectedIndices : []; 
         this.errorShowing = false;
         this.pizza = getPizza(this.selectedIndices.map((i) => this.collectedIngredients[i]));
-        this.pizzaInfo = this.sceneRouter.load(dataKeys.pizzaInfo);
 
+        this.pizzaInfo = new PizzaInfo();
+        const slots = this.sceneRouter.load(dataKeys.slots);
+        const slot = slots[this.sharedData.playingSlotIndex];
+
+        if (slot && slot.stageResults) {
+            for (const stageResult of slot.stageResults) {
+                const pizza = stageResult.pizza;
+                this.pizzaInfo.unlock(pizza);
+            }
+        }
     }
 
     updateStates(deltaTime) {}

--- a/js/scene/CookingScene.mjs
+++ b/js/scene/CookingScene.mjs
@@ -3,6 +3,7 @@ import { scenes } from "./special/sceneSettings.mjs";
 import { imageForIngredient, ingredientName } from '../gameObject/ingredients.mjs';
 import { getPizza, imageForPizza, pizzaName } from '../gameObject/pizzas.mjs';
 import { resource } from '../resource.mjs';
+import { dataKeys } from '../dataObject/dataKeysSettings.mjs';
 
 import { ingredientType } from '../gameObject/ingredients.mjs';
 
@@ -17,6 +18,8 @@ export class CookingScene extends Scene {
             this.sharedData.selectedIndices : []; 
         this.errorShowing = false;
         this.pizza = getPizza(this.selectedIndices.map((i) => this.collectedIngredients[i]));
+        this.pizzaInfo = this.sceneRouter.load(dataKeys.pizzaInfo);
+
     }
 
     updateStates(deltaTime) {}
@@ -105,7 +108,8 @@ export class CookingScene extends Scene {
     drawPizza(ctx, x, y, width, height) {
         if (!this.pizza) return;
         const name = pizzaName[this.pizza];
-        const image = imageForPizza(this.pizza);
+        const isUnlocked = this.pizzaInfo.isUnlocked(this.pizza);
+        const image = isUnlocked ? imageForPizza(this.pizza) : resource.images.unknownPizza;
         if (image.complete) {
             ctx.drawImage(image, x, y + height - width, width, width);
             ctx.font = "24px Arial";


### PR DESCRIPTION
close #86 

CookingSceneにて、選択した食材でできるピザの画像を、該当のピザがアンロックされていない場合に？マークにするように変更