### PR TITLE
Fix: 優先順位的に肉ピザを生成できないバグを修正

### DIFF
--- a/js/gameObject/pizzas.mjs
+++ b/js/gameObject/pizzas.mjs
@@ -118,8 +118,8 @@ export const pizzaPriorityOrder = [
     pizzas.diabola,
     pizzas.teriyakiPizza,
     pizzas.mayoCorn,
-    pizzas.baconPizza,
     pizzas.meatPizza,
+    pizzas.baconPizza,
     pizzas.uniquePizza,
 ]
 


### PR DESCRIPTION
close #93 

肉ピザとベーコンピザの優先順位を反対にしました。
全てのピザが作れることを確認済みです。