### PR TITLE
Fix: SlotSelectionSceneのBGMを削除

### DIFF
--- a/js/scene/SlotSelectionScene.mjs
+++ b/js/scene/SlotSelectionScene.mjs
@@ -14,7 +14,6 @@ import { buttonStates, ColorButton } from '../component/Button.mjs';
 //   - this.sharedData.playingSlotIndex: 現在プレイしているスロット番号
 export class SlotSelectionScene extends Scene {
     sceneWillAppear(){
-        this.sceneRouter.setBGM(resource.bgm.MusMusBGM103);
         this.setUpUI();
     }
 


### PR DESCRIPTION
セーブデータ選択画面でのsetBGMを削除しました。
ResultSceneで表示された際に、ResultSceneのBGMが消えてタイトルのBGMが流れてしまったためです。