### PR TITLE
Change: SlotにstageではなくstageNumberを保存

### DIFF
--- a/js/dataObject/Slot.mjs
+++ b/js/dataObject/Slot.mjs
@@ -23,7 +23,7 @@ export class Slot {
             return 0;
         } else {
             return this.stageResults.reduce((max, result) => {
-                return Math.max(max,result.stage.stageNumber);
+                return Math.max(max,result.stageNumber);
             }, 1);
         }
     }

--- a/js/dataObject/StageResult.mjs
+++ b/js/dataObject/StageResult.mjs
@@ -1,7 +1,7 @@
 // ステージを1回クリアするごとに生成される結果の情報
 export class StageResult {
-    constructor(stage, score, pizza, goalTime, gameOverCount, collisionCount, collectedIngredient) {
-        this.stage = stage;
+    constructor(stageNumber, score, pizza, goalTime, gameOverCount, collisionCount, collectedIngredient) {
+        this.stageNumber = stageNumber;
         this.score = score;
         this.pizza = pizza;
         this.goalTime = goalTime;
@@ -11,8 +11,9 @@ export class StageResult {
     }
 
     static createFromJSONData(data) {
+        if (data.stage) data.stageNumber = data.stage.stageNumber;  // 古いバージョンとの互換性保持
         return new StageResult(
-            data.stage,
+            data.stageNumber,
             data.score,
             data.pizza,
             data.goalTime,

--- a/js/gameObject/endings.mjs
+++ b/js/gameObject/endings.mjs
@@ -129,14 +129,14 @@ export function judgeEnding(slot) {
 
     const isEveryExceedTargetTime =
     slot.stageResults.every(result => {
-        const stage = result.stage;
+        const stage = stages[result.stageNumber];
         return stage && result.goalTime > stage.targetTime;
     })
 
     const totalScore = Object.keys(stages).map((stageNumber) =>
         // stages[stageNumber] のスコアの最大値
         slot.stageResults
-            .filter((result) => result.stage.stageNumber == stageNumber)
+            .filter((result) => result.stageNumber == stageNumber)
             .map((result) => result.score)
             .reduce((maxScore, score) => Math.max(maxScore, score))
     ).reduce((total, score) => total + score, 0)

--- a/js/scene/ResultScene.mjs
+++ b/js/scene/ResultScene.mjs
@@ -126,7 +126,7 @@ export class ResultScene extends Scene {
             return;
         }
         const stageResult = new StageResult(
-            this.sharedData.stage,
+            this.sharedData.stage.stageNumber,
             this.totalScore,
             this.sharedData.cookedPizza,
             this.sharedData.goalTime,


### PR DESCRIPTION
Slotにstageオブジェクトを保存するとLocalStorageの容量が増えてしまうので、stageNumberを保存するようにしました。
古い形式でプレイした場合は、dataKeys.slotsが保存される時にこの形式に変換されて保存されるので問題ありません。

## 効果の検証結果
僕の従来の形式でのLocal Storageを新しい形式にして比較してみました。(エンコーディング方式はUTF-8)
従来の形式：500.0KB
新しい形式：19.25KB (96.15%削減)