### PR TITLE
Fix: スマホでCanvasが選択されないように修正

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -10,6 +10,13 @@ body {
     justify-content: center;
     align-items: center;
     overflow: hidden;
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    -khtml-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+    -webkit-tap-highlight-color: rgba(0,0,0,0);
 }
 
 #layout {

--- a/js/SceneRouter.mjs
+++ b/js/SceneRouter.mjs
@@ -40,16 +40,10 @@ class MouseHandler {
         this.startTrackingMouse();
     }
 
-    listenClick(callback) {
-        this.canvas.addEventListener("click", function(e) {
-            const pos = this.getCanvasMousePosition(e);
-            callback(pos.x, pos.y);
-        }.bind(this));
-    }
-
     startTrackingMouse() {
         // マウス操作
         this.canvas.addEventListener("mousedown", function(e) {
+            e.preventDefault();
             this.mouse.isDown = true;
             this.mouse.startX = this.mouse.x;
             this.mouse.startY = this.mouse.y;
@@ -68,6 +62,7 @@ class MouseHandler {
 
         // タッチ操作
         this.canvas.addEventListener("touchstart", function(e) {
+            e.preventDefault();
             this.mouse.isDown = true;
             const pos = this.getCanvasTouchPosition(e);
             this.mouse.x = pos.x;
@@ -140,14 +135,6 @@ export class SceneRouter {
         this.mouseHandler = new MouseHandler(canvas);
         this.keyHandler = new KeyHandler()
         this.localDBHandler = new LocalDBHandler();
-
-        this.mouseHandler.listenClick(function(x, y) {
-            if (this.presentingModal) {
-                this.presentingModal.didTap?.(x, y);
-            } else if (this.currentScene) {
-                this.currentScene.didTap?.(x, y);
-            }
-        }.bind(this));
 
         resource.startLoadingAllImages();
     }

--- a/js/scene/special/Scene.mjs
+++ b/js/scene/special/Scene.mjs
@@ -56,11 +56,4 @@ export class Scene {
      * シーンが閉じる時に行いたい処理がある場合、このメソッドをオーバーライドする。
      */
     sceneWillDisappear() {}
-
-    /**
-     * キャンバス内がタップされた時の処理を書く場合、このメソッドをオーバーライドする。
-     * @param {number} x - タップされた場所のCanvas内のx座標
-     * @param {number} y - タップされた場所のCanvas内のy座標
-     */
-    didTap(x, y) {}
 }


### PR DESCRIPTION
close #171 
30ad1bebb5e1b9e8407f673476a8bc13941d465e でのpreventDefaultによってclickイベントが検知できなくなったため、SceneのdidTap関数を削除しました。
didTap関数をオーバーライドしているシーンはないので影響はありません。